### PR TITLE
Use hweight_long from linux/bitops.h instead of popcount intrinsic

### DIFF
--- a/asus-ec-sensors.c
+++ b/asus-ec-sensors.c
@@ -242,7 +242,7 @@ static int bank_compare(const void* a, const void* b)
 
 static inline int board_sensors_count(enum board board)
 {
-	return __builtin_popcount(known_board_sensors[board]);
+	return hweight_long(known_board_sensors[board]);
 }
 
 static void __init setup_sensor_data(struct ec_sensors_data *ec, board_t board)


### PR DESCRIPTION
When I try to compile this module, I get the following errors:

```
ERROR: modpost: "__popcountdi2" [/home/nick/asus-ec-sensors/asus-ec-sensors.ko] undefined!
make[3]: *** [/nix/store/5d0q1n5h3vin2fyqcsdk279r1jk9cqf5-linux-5.10.84-dev/lib/modules/5.10.84/source/scripts/Makefile.modpost:124: /home/nick/asus-ec-sensors/Module.symvers] Error 1
make[3]: *** Deleting file '/home/nick/asus-ec-sensors/Module.symvers'
make[2]: *** [/nix/store/5d0q1n5h3vin2fyqcsdk279r1jk9cqf5-linux-5.10.84-dev/lib/modules/5.10.84/source/Makefile:1726: modules] Error 2
make[1]: *** [/nix/store/5d0q1n5h3vin2fyqcsdk279r1jk9cqf5-linux-5.10.84-dev/lib/modules/5.10.84/source/Makefile:185: __sub-make] Error 2
make: *** [Makefile:32: modules] Error 2
```

It suggests that the kernel module compile environment isn't able to resolve symbol for the intrinsic `__builtin_popcount`. I tried but failed to determine whether this was an issue with my environment, but I am able to compile other out-of-tree modules generally fine.

I've replaced it with a wrapper from linux which I believe should be functionally equivalent. Not sure if this is considered better style, but it fixes the errors for me.