### PR TITLE
Remove VRM temp sensor from X570-E GAMING

### DIFF
--- a/asus-ec-sensors.c
+++ b/asus-ec-sensors.c
@@ -420,7 +420,7 @@ static const struct ec_board_info board_info_strix_b550_i_gaming = {
 
 static const struct ec_board_info board_info_strix_x570_e_gaming = {
 	.sensors = SENSOR_SET_TEMP_CHIPSET_CPU_MB |
-		SENSOR_TEMP_T_SENSOR | SENSOR_TEMP_VRM |
+		SENSOR_TEMP_T_SENSOR |
 		SENSOR_FAN_CHIPSET | SENSOR_CURR_CPU |
 		SENSOR_IN_CPU_CORE,
 	.mutex_path = ASUS_HW_ACCESS_MUTEX_ASMX,


### PR DESCRIPTION
No hardware support for this sensor on this board.

Please see:

> ASUS has neglected to utilize an integrated thermal sensor on all but its top tier AM4 models which is disappointing.

https://www.anandtech.com/show/16348/asus-rog-strix-x570e-gaming-motherboard-review/9

