### PR TITLE
Added kernel version check for kernel >= 6.12.0

### DIFF
--- a/asus-ec-sensors.c
+++ b/asus-ec-sensors.c
@@ -33,8 +33,13 @@
 #include <linux/platform_device.h>
 #include <linux/sort.h>
 #include <linux/units.h>
+#include <linux/version.h>
 
+#if LINUX_VERSION_CODE < KERNEL_VERSION(6,12,0)
 #include <asm/unaligned.h>
+#else
+#include <linux/unaligned.h>
+#endif
 
 static char *mutex_path_override;
 


### PR DESCRIPTION
Starting  from kernel 6.12 **asm/unaligned.h** has been moved to **linux/unaligned.h**.  

Reference: https://lkml.org/lkml/2024/10/6/423


