### PR TITLE
Add MAXIMUS VI HERO motherboard

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ the hwmon-next branch.
 
 ## Supported motherboards
 
+ * MAXIMUS VI HERO
  * PRIME X470-PRO
  * PRIME X570-PRO
  * Pro WS X570-ACE

--- a/asus-ec-sensors.c
+++ b/asus-ec-sensors.c
@@ -311,6 +311,15 @@ struct ec_board_info {
 	enum board_family family;
 };
 
+static const struct ec_board_info board_info_maximus_vi_hero = {
+	.sensors = SENSOR_SET_TEMP_CHIPSET_CPU_MB |
+		SENSOR_TEMP_T_SENSOR |
+		SENSOR_TEMP_VRM | SENSOR_SET_TEMP_WATER |
+		SENSOR_FAN_CPU_OPT | SENSOR_FAN_WATER_FLOW,
+	.mutex_path = ACPI_GLOBAL_LOCK_PSEUDO_PATH,
+	.family = family_intel_300_series,
+};
+
 static const struct ec_board_info board_info_prime_x470_pro = {
 	.sensors = SENSOR_SET_TEMP_CHIPSET_CPU_MB |
 		SENSOR_TEMP_T_SENSOR | SENSOR_TEMP_VRM |
@@ -406,7 +415,7 @@ static const struct ec_board_info board_info_maximus_xi_hero = {
 };
 
 static const struct ec_board_info board_info_maximus_z690_formula = {
-	.sensors = SENSOR_TEMP_T_SENSOR | SENSOR_TEMP_VRM | 
+	.sensors = SENSOR_TEMP_T_SENSOR | SENSOR_TEMP_VRM |
 		SENSOR_SET_TEMP_WATER | SENSOR_FAN_WATER_FLOW,
 	.mutex_path = ASUS_HW_ACCESS_MUTEX_RMTW_ASMX,
 	.family = family_intel_600_series,
@@ -508,6 +517,8 @@ static const struct ec_board_info board_info_zenith_ii_extreme = {
 	}
 
 static const struct dmi_system_id dmi_table[] = {
+	DMI_EXACT_MATCH_ASUS_BOARD_NAME("MAXIMUS VI HERO",
+					&board_info_maximus_vi_hero),
 	DMI_EXACT_MATCH_ASUS_BOARD_NAME("PRIME X470-PRO",
 					&board_info_prime_x470_pro),
 	DMI_EXACT_MATCH_ASUS_BOARD_NAME("PRIME X570-PRO",


### PR DESCRIPTION
Add MAXIMUS VI HERO motherboard to the list

use `grep -e ''  -n /sys/class/dmi/id/board_{name,vendor}` to obtain the name:
```
/sys/class/dmi/id/board_name:1:MAXIMUS VI HERO
/sys/class/dmi/id/board_vendor:1:ASUSTeK COMPUTER INC.
```