### PR TITLE
Add support for MAXIMUS X HERO

### DIFF
--- a/asus-ec-sensors.c
+++ b/asus-ec-sensors.c
@@ -63,6 +63,8 @@ static char *mutex_path_override;
 
 #define ASUS_HW_ACCESS_MUTEX_SB_PCI0_SBRG_SIO1_MUT0 "\\_SB_.PCI0.SBRG.SIO1.MUT0"
 
+#define ASUS_HW_ACCESS_MUTEX_SB_PCI0_LPCB_SIO1_MUT0 "\\_SB_.PCI0.LPCB.SIO1.MUT0"
+
 #define MAX_IDENTICAL_BOARD_VARIATIONS	3
 
 /* Moniker for the ACPI global lock (':' is not allowed in ASL identifiers) */
@@ -420,6 +422,15 @@ static const struct ec_board_info board_info_crosshair_viii_hero = {
 	.family = family_amd_500_series,
 };
 
+static const struct ec_board_info board_info_maximus_x_hero = {
+	.sensors = SENSOR_SET_TEMP_CHIPSET_CPU_MB |
+		SENSOR_TEMP_T_SENSOR |
+		SENSOR_TEMP_VRM | SENSOR_SET_TEMP_WATER |
+		SENSOR_FAN_CPU_OPT | SENSOR_FAN_WATER_FLOW,
+	.mutex_path = ASUS_HW_ACCESS_MUTEX_SB_PCI0_LPCB_SIO1_MUT0, 
+	.family = family_intel_300_series,
+};
+
 static const struct ec_board_info board_info_maximus_xi_hero = {
 	.sensors = SENSOR_SET_TEMP_CHIPSET_CPU_MB |
 		SENSOR_TEMP_T_SENSOR |
@@ -569,6 +580,8 @@ static const struct dmi_system_id dmi_table[] = {
 					&board_info_crosshair_x670e_hero),
 	DMI_EXACT_MATCH_ASUS_BOARD_NAME("ROG CROSSHAIR X670E GENE",
 					&board_info_crosshair_x670e_gene),
+	DMI_EXACT_MATCH_ASUS_BOARD_NAME("ROG MAXIMUS X HERO",
+					&board_info_maximus_x_hero),
 	DMI_EXACT_MATCH_ASUS_BOARD_NAME("ROG MAXIMUS XI HERO",
 					&board_info_maximus_xi_hero),
 	DMI_EXACT_MATCH_ASUS_BOARD_NAME("ROG MAXIMUS XI HERO (WI-FI)",


### PR DESCRIPTION
Adds support for ROG MAXIMUS X HERO.

 `grep -e ''  -n /sys/class/dmi/id/board_{name,vendor}` to obtain the name:

```
/sys/class/dmi/id/board_name:1:ROG MAXIMUS X HERO
/sys/class/dmi/id/board_vendor:1:ASUSTeK COMPUTER INC.
```

Included the dsdt.dat as a zip
[dsdt.dat.zip](https://github.com/user-attachments/files/20234630/dsdt.dat.zip)

Here's my relevant sensors output section built on 6.14.6-2-cachyos (I use Arch btw):

```
asusec-isa-0000
Adapter: ISA adapter
CPU_Opt:        0 RPM
Water_Flow:     0 RPM
Chipset:      +47.0°C  
CPU:          +35.0°C  
Motherboard:  +32.0°C  
T_Sensor:     +30.0°C  
VRM:           +0.0°C  
Water_In:      +0.0°C  
Water_Out:     +0.0°C  
```

As per our discussion in [issue63](https://github.com/zeule/asus-ec-sensors/issues/63) all I really wanted was T_Sensor but now I have found the MUTEX in the dsl file so I added that.

I don't have anything plugged into CPU_OPT, Water_Flow, VRM, Water_In, Water_Out, so that appears correct. The motherboard and T_Sensor temperatures are the same as my BIOS.