### PR TITLE
hwmon: (asus-ec-sensors) add CPU Package and CPU_Opt for STRIX B650E-E

### DIFF
--- a/asus-ec-sensors.c
+++ b/asus-ec-sensors.c
@@ -622,8 +622,9 @@ static const struct ec_board_info board_info_strix_b550_i_gaming = {
 };
 
 static const struct ec_board_info board_info_strix_b650e_e_gaming = {
-	.sensors = SENSOR_TEMP_VRM | SENSOR_SET_TEMP_CHIPSET_CPU_MB |
-		SENSOR_IN_CPU_CORE,
+	.sensors = SENSOR_TEMP_CPU | SENSOR_TEMP_CPU_PACKAGE |
+		SENSOR_TEMP_MB | SENSOR_TEMP_VRM |
+		SENSOR_FAN_CPU_OPT,
 	.mutex_path = ASUS_HW_ACCESS_MUTEX_SB_PCI0_SBRG_SIO1_MUT0,
 	.family = family_amd_600_series,
 };


### PR DESCRIPTION
Follow-up to #102, which added this board.

That PR's entry enables `SENSOR_SET_TEMP_CHIPSET_CPU_MB` and
`SENSOR_IN_CPU_CORE`, but `sensors_family_amd_600` defines no register
for a chipset temperature or CPU core voltage, so those two never
produce a reading.

The `family_amd_600` table *does* define **CPU Package** temperature
(register `0x31`) and the **CPU_Opt** fan (`0xb0`), both present on this
board and simply not enabled. This switches the entry to the explicit
sensor set already used by the sibling 600-series boards
(X670E-E / X670E-I), and additionally enables the CPU_Opt fan.

### Verified on hardware

ROG STRIX B650E-E GAMING WIFI, Ryzen 9 9900X, kernel 7.0.8:

```
asusec-isa-000a
Adapter: ISA adapter
CPU_Opt:     1188 RPM
CPU:          +56.0°C
CPU Package:  +67.0°C
Motherboard:  +41.0°C
VRM:          +58.0°C
```

`CPU` and `CPU Package` both report valid, live temperatures that
respond to load; `CPU_Opt` reports the fan on the CPU_OPT header
(900-1330 RPM observed across load). `CPU Package` uses register
`0x31`, already enabled for `family_amd_600` on the X670E-E / X670E-I;
`CPU_Opt` uses the standard `0xb0` fan register.

A DSDT dump for this board (binary, gzipped) is available:

[dsdt.dat.gz](https://github.com/user-attachments/files/27858995/dsdt.dat.gz)

